### PR TITLE
adjust Suricata Dockerfile to best practices

### DIFF
--- a/docker/suricata/Dockerfile
+++ b/docker/suricata/Dockerfile
@@ -4,31 +4,22 @@
 FROM ubuntu
 
 # File Author
-MAINTAINER gradiuscypher
+LABEL maintainer='gradiuscypher' \
+      source_repo='https://github.com/gradiuscypher/grIDS'
 
-# Update the repos
-RUN apt update
-
-# Allows us to add repositories
-RUN apt install -y software-properties-common wget apt-transport-https
-
-# Add the Elastic key for Filebeat and add repo
-RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-RUN echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-6.x.list
-
-# Add the Suricata repository
-RUN add-apt-repository -y ppa:oisf/suricata-stable
-
-# Update the repos and install Suricata
-RUN apt update && apt install -y suricata
-
-# Install Filebeat
-RUN apt install -y filebeat
+# Update the main repo, add repos and install filebeat and suricata
+RUN apt update && \
+    apt install -y software-properties-common wget apt-transport-https && \
+    wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
+    echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-6.x.list && \
+    add-apt-repository -y ppa:oisf/suricata-stable && \
+    apt update && apt install -y suricata && \
+    apt install -y filebeat
 
 # Copy the suricata config to its config location
 ADD filebeat.yml /etc/filebeat
-RUN chown root /etc/filebeat/filebeat.yml
-RUN chmod 0644 /etc/filebeat/filebeat.yml
+RUN chown root /etc/filebeat/filebeat.yml && \
+    chmod 0644 /etc/filebeat/filebeat.yml
 
 # Copy the suricata config to its config location
 ADD suricata.yaml /etc/suricata/suricata.yaml


### PR DESCRIPTION
- 'RUN' directives concatenated (every 'RUN' command adds another layer to the image, making it heavier - concatenating creates a single layer whilst still running all the necessary commands)
- Replacing deprecated 'MAINTAINER' with 'LABEL' - mostly cosmetics
- Ideally the cointainer shouldn't run as root, so it'd be a good idea to use USER ${>1000} (greater than 1000) command so as to run the container as a non-root user; since I haven't thoroughly tested the rest of the code, I'm not adding it here but leaving it as a suggestion